### PR TITLE
Update account name

### DIFF
--- a/docs/overview/concepts/transferable-account.md
+++ b/docs/overview/concepts/transferable-account.md
@@ -118,7 +118,7 @@ sequenceDiagram
 
 Mycel is a decentralized platform that aims to provide secure and private transactions while maintaining the integrity and verifiability of the system. One of the key components in achieving these goals is the use of threshold signatures, specifically the [Flexible Round-Optimized Schnorr Threshold (FROST) signature scheme](https://eprint.iacr.org/2020/852).
 
-One of the primary reasons Mycel has chosen to employ FROST is its unique property of maintaining a fixed public key, even when the set of signers changes. In Mycel, users' assets are held in transferable account, each associated with a unique public key. The security and ownership of these FAs are distributed among a group of validators using FROST.
+One of the primary reasons Mycel has chosen to employ FROST is its unique property of maintaining a fixed public key, even when the set of signers changes. In Mycel, users' assets are held in transferable account, each associated with a unique public key. The security and ownership of these TAs are distributed among a group of validators using FROST.
 
 ## Specification
 

--- a/docs/overview/what_to_build.md
+++ b/docs/overview/what_to_build.md
@@ -17,7 +17,7 @@ Transferable Account serves as a gateway for interacting with native assets on a
 3. Transfer Validation
    - Application validates the asset transfer to ensure its integrity and correctness.
 4. Update Ownership:
-   - Upon successful validation, the ownership of the FA is transferred from the Swapper to the Solver.
+   - Upon successful validation, the ownership of the TA is transferred from the Swapper to the Solver.
 
 ## Transfer assets on any chain from smart contracts or rollups on any other chain
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated terminology in the ownership transfer process for Transferable Accounts to enhance clarity. The term "FA" has been replaced with "TA" for improved specificity regarding asset ownership transitions.
	- Streamlined the terminology used for accounts by changing "transferable account" to "TAs" in the documentation, maintaining focus on the decentralized nature of the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->